### PR TITLE
🧪 test(components, providers): add test to provider theme, locale, up…

### DIFF
--- a/src/components/common/custom-tooltip/custom-tooltip.tsx
+++ b/src/components/common/custom-tooltip/custom-tooltip.tsx
@@ -9,6 +9,7 @@ function CustomTooltip({ children, ...tooltipProps }: TooltipProps) {
       color="black"
       bg="#36d399"
       fontSize="small"
+      //* set vertical offset to 12
       offset={[0, 12]}
       {...tooltipProps}
     >

--- a/src/components/common/custom-tooltip/custom-tooltip.tsx
+++ b/src/components/common/custom-tooltip/custom-tooltip.tsx
@@ -9,6 +9,7 @@ function CustomTooltip({ children, ...tooltipProps }: TooltipProps) {
       color="black"
       bg="#36d399"
       fontSize="small"
+      offset={[0, 12]}
       {...tooltipProps}
     >
       {children}

--- a/src/components/common/github-star-button/__tests__/github-star-button.test.tsx
+++ b/src/components/common/github-star-button/__tests__/github-star-button.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { NextIntlClientProvider } from 'next-intl';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -10,7 +11,19 @@ describe('GithubStarButton', () => {
 
   beforeEach(() => {
     render(
-      <NextIntlClientProvider locale="en">
+      <NextIntlClientProvider
+        locale="en"
+        messages={{
+          components: {
+            common: {
+              githubStarButton: {
+                label: 'Star on GitHub',
+                tooltip: 'Star this project on GitHub',
+              },
+            },
+          },
+        }}
+      >
         <GithubStarButton href={href} count={count} />
       </NextIntlClientProvider>,
     );
@@ -20,7 +33,7 @@ describe('GithubStarButton', () => {
     const link = screen.getByRole('link');
 
     expect(link).toBeVisible();
-    // expect(link).toHaveAttribute('aria-label', 'Star on GitHub');
+    expect(link).toHaveAttribute('aria-label', 'Star on GitHub');
     expect(link).toHaveAttribute('href', href);
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener');
@@ -28,5 +41,15 @@ describe('GithubStarButton', () => {
 
   it('should render correctly the star count', () => {
     screen.getByText(count.toString());
+  });
+
+  it('should render tooltip correctly', async () => {
+    const link = screen.getByRole('link');
+
+    const user = userEvent.setup();
+    await user.hover(link);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Star this project on GitHub');
   });
 });

--- a/src/components/common/github-star-button/github-star-button.tsx
+++ b/src/components/common/github-star-button/github-star-button.tsx
@@ -14,7 +14,7 @@ function GithubStarButton({ href, count }: GithubStarButtonProps) {
   const t = useTranslations('components.common.githubStarButton');
 
   return (
-    <CustomTooltip label={t('tooltip')} hasArrow>
+    <CustomTooltip label={t('tooltip')} hasArrow isOpen>
       <Link
         href={href}
         target="_blank"

--- a/src/components/common/github-star-button/github-star-button.tsx
+++ b/src/components/common/github-star-button/github-star-button.tsx
@@ -14,7 +14,7 @@ function GithubStarButton({ href, count }: GithubStarButtonProps) {
   const t = useTranslations('components.common.githubStarButton');
 
   return (
-    <CustomTooltip label={t('tooltip')} hasArrow isOpen>
+    <CustomTooltip label={t('tooltip')} hasArrow>
       <Link
         href={href}
         target="_blank"

--- a/src/providers/__tests__/locale-provider.test.tsx
+++ b/src/providers/__tests__/locale-provider.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { NextIntlClientProvider, useMessages, useTimeZone } from 'next-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import LocaleProvider from '../locale-provider';
+
+vi.mock('next-intl', () => ({
+  NextIntlClientProvider: vi.fn(({ children }) => children),
+  useMessages: vi.fn(() => ({
+    'en-US': { greeting: 'Hello!' },
+    'vi-VN': { greeting: 'Xin chào!' },
+  })),
+  useTimeZone: vi.fn(() => 'UTC'),
+}));
+
+describe('LocaleProvider', () => {
+  it('should render with correct messages and timezone', () => {
+    render(
+      <LocaleProvider>
+        <div>Child</div>
+      </LocaleProvider>,
+    );
+
+    expect(useMessages).toHaveBeenCalled();
+    expect(useTimeZone).toHaveBeenCalled();
+    expect(NextIntlClientProvider).toHaveBeenCalledWith(
+      {
+        messages: {
+          'en-US': { greeting: 'Hello!' },
+          'vi-VN': { greeting: 'Xin chào!' },
+        },
+        timeZone: 'UTC',
+        children: <div>Child</div>,
+      },
+      expect.any(Object),
+    );
+  });
+});

--- a/src/providers/__tests__/theme-provider.test.tsx
+++ b/src/providers/__tests__/theme-provider.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider as NextThemeProvider } from 'next-themes';
+import { describe, expect, it, vi } from 'vitest';
+
+import { THEME_ATTRIBUTE, THEME_STORAGE_KEY, themes } from '@/configs/themes';
+
+import ThemeProvider from '../theme-provider';
+
+//* Mocking NextThemeProvider is done to isolate the component under test, which is ThemeProvider in this case.
+//* This is a common practice in unit testing where the goal is to test the component in isolation from its dependencies.
+
+//* By mocking NextThemeProvider, you ensure that the test isn't affected by the implementation details of NextThemeProvider.
+//* This makes the test more reliable(it won't break if NextThemeProvider changes)
+//* and more focused(it only tests the behavior of ThemeProvider).
+vi.mock('next-themes', () => ({
+  ThemeProvider: vi.fn(({ children }) => children),
+}));
+
+describe('ThemeProvider', () => {
+  it('should render NextThemeProvider with the correct props', () => {
+    render(
+      <ThemeProvider>
+        <div>Mock Component</div>
+      </ThemeProvider>,
+    );
+
+    expect(NextThemeProvider).toHaveBeenCalledWith(
+      {
+        themes: [themes.LIGHT, themes.DARK],
+        attribute: THEME_ATTRIBUTE,
+        defaultTheme: themes.SYSTEM,
+        enableSystem: true,
+        storageKey: THEME_STORAGE_KEY,
+        children: <div>Mock Component</div>,
+      },
+      expect.any(Object),
+    );
+
+    expect(screen.getByText('Mock Component')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
…date test github-star-button